### PR TITLE
Clean up unused code in frontend and database

### DIFF
--- a/backend/database/db.py
+++ b/backend/database/db.py
@@ -8,7 +8,6 @@ DB_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "database.db"
 def get_connection():
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
-    print(f"Connecting to database at {DB_PATH}")
     return conn
 
 # ---------- Prompt helpers ----------
@@ -209,11 +208,9 @@ def get_chat_feedback_summary(chat_id: str):
 def update_epitome_eval(chat_id: str, pair_number: int, epitome_eval_json: dict):
     with get_connection() as conn:
         cursor = conn.cursor()
-        print(f"Updating chat_id={chat_id}, pair_number={pair_number}...")
         cursor.execute("""
             UPDATE chat_pairs
             SET epitome_eval = ?
             WHERE chat_id = ? AND pair_number = ?
         """, (json.dumps(epitome_eval_json), chat_id, pair_number))
         conn.commit()
-        print(f"Rows affected: {cursor.rowcount}")

--- a/frontend/pages/0_Chat.py
+++ b/frontend/pages/0_Chat.py
@@ -1,19 +1,14 @@
 # 0_Chat.py – Empathic Chatbot with Streamlit
 
+import pathlib
+import sys
+import uuid
+import threading
+
 import streamlit as st
 from dotenv import load_dotenv
-import pathlib, sys, uuid, json
-from PyPDF2 import PdfReader
-import threading
+
 from backend.services.epitome_evaluation import call_epitome_model
-
-DATA_DIR = pathlib.Path("data")
-MANIFEST_PATH = DATA_DIR / "doc_manifest.json"
-
-# ensure an empty manifest file exists on every cold start
-if not MANIFEST_PATH.exists():
-    DATA_DIR.mkdir(exist_ok=True)
-    MANIFEST_PATH.write_text("[]", encoding="utf-8")
 
 
 
@@ -44,11 +39,17 @@ PROJECT_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
 # 3) Additional imports
-from backend.llm.replicate_client_chatbot import ReplicateClientChatbot
-from backend.utils.check_secrets import get_secret
-from backend.database.db import create_tables, insert_chat_pair, get_recent_pairs, update_user_feedback, \
-    get_feedback_statistics, get_active_prompt_id, update_epitome_eval
-from backend.llm.document_retriever_RAG import DocumentRetriever
+from backend.llm.replicate_client_chatbot import ReplicateClientChatbot  # noqa: E402
+from backend.utils.check_secrets import get_secret  # noqa: E402
+from backend.database.db import (  # noqa: E402
+    create_tables,
+    insert_chat_pair,
+    update_user_feedback,
+    get_feedback_statistics,
+    get_active_prompt_id,
+    update_epitome_eval,
+)
+from backend.llm.document_retriever_RAG import DocumentRetriever  # noqa: E402
 
 # 5) Initialize retriever
 retriever = DocumentRetriever()
@@ -98,7 +99,7 @@ for i, turn in enumerate(st.session_state.chat_history):
                     user_feedback=stars,
                 )
                 st.session_state.feedback_given.add(i)
-                st.toast(f"Thanks for your feedback!")
+                st.toast("Thanks for your feedback!")
 
 # New input
 if user_input := st.chat_input("Type your message..."):

--- a/frontend/pages/2_empathy-testing-basic-table.py
+++ b/frontend/pages/2_empathy-testing-basic-table.py
@@ -1,11 +1,10 @@
 import streamlit as st
 import pandas as pd
 import sqlite3
-from pathlib import Path
+
 from backend.database.db import (
-    get_connection,
     update_epitome_eval,
-    DB_PATH
+    DB_PATH,
 )
 from backend.services.epitome_evaluation import call_epitome_model
 
@@ -29,8 +28,6 @@ if not st.session_state.get("is_admin", False):
 
 
 # Check Database is there
-print(f"DB_PATH being used: {DB_PATH}")
-print(f"Exists? {DB_PATH.exists()}")
 
 def load_chats_from_db():
     conn = sqlite3.connect(DB_PATH)

--- a/frontend/pages/3_empathy-testing-prettier.py
+++ b/frontend/pages/3_empathy-testing-prettier.py
@@ -4,7 +4,6 @@ import streamlit as st
 import pandas as pd
 import sqlite3
 from backend.database.db import (
-    get_connection,
     update_epitome_eval,
     DB_PATH
 )
@@ -30,8 +29,6 @@ if not st.session_state.get("is_admin", False):
 
 
 # Check Database is there
-print(f"DB_PATH being used: {DB_PATH}")
-print(f"Exists? {DB_PATH.exists()}")
 
 def load_chats_from_db():
     conn = sqlite3.connect(DB_PATH)
@@ -118,5 +115,4 @@ for chat_id, group in grouped:
             if row["user_feedback"]:
                 st.markdown("**📝 User Feedback:**")
                 st.info(f"{row['user_feedback']}")
-
             st.markdown("---")

--- a/frontend/pages/4_RAG_Documents.py
+++ b/frontend/pages/4_RAG_Documents.py
@@ -1,9 +1,10 @@
 import streamlit as st
-import pathlib, json
+import pathlib
+import json
 from pymilvus import utility, connections
 from backend.llm.document_retriever_RAG import DocumentRetriever
 
-st.set_page_config("🛠️ RAG Documents")
+st.set_page_config(page_title="RAG Documents", page_icon="📚")
 
 # Admin Page Logic
 if "is_admin" not in st.session_state:
@@ -22,7 +23,6 @@ if not st.session_state.get("is_admin", False):
     st.stop()
 
 # — config
-st.set_page_config(page_title="RAG Documents", page_icon="📚")
 DATA_DIR = pathlib.Path("data")
 DOCS_DIR = pathlib.Path("docs")
 MANIFEST_PATH = DATA_DIR / "doc_manifest.json"
@@ -146,7 +146,8 @@ else:
         if col2.button("🗑️ Delete", key=f"del_{fname}"):
             # 1) delete file on disk
             fp = DOCS_DIR / fname
-            if fp.exists(): fp.unlink()
+            if fp.exists():
+                fp.unlink()
 
             # 2) delete vectors from Milvus
             expr = f"source == '{fname}'"

--- a/frontend/pages/5_Empathy_Dashboard.py
+++ b/frontend/pages/5_Empathy_Dashboard.py
@@ -3,7 +3,6 @@ import json
 import re
 import pandas as pd
 import sqlite3
-import matplotlib.pyplot as plt
 
 from backend.database.db import DB_PATH
 


### PR DESCRIPTION
## Summary
- streamline Streamlit chat module by removing unused imports and helper code
- drop debug prints and dead imports from admin/testing pages
- simplify RAG document manager and database helper routines

## Testing
- `ruff check frontend/pages/0_Chat.py frontend/pages/2_empathy-testing-basic-table.py frontend/pages/3_empathy-testing-prettier.py frontend/pages/4_RAG_Documents.py frontend/pages/5_Empathy_Dashboard.py backend/database/db.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f61ec96288323b97f0eefa731c7a3