### PR TITLE
Fix nginx upstream mapping to prevent 502 errors

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,18 +1,14 @@
 events {}
 
 http {
-  # Use Docker's embedded DNS and refresh periodically
-  resolver 127.0.0.11 valid=10s ipv6=off;
-
-  # For dynamic proxy_pass (resolves at request time)
-  map $http_host $backend {
-    default "http://chatbot-app:8501";
-  }
-
   # WebSocket/SSE upgrade map
   map $http_upgrade $connection_upgrade {
     default upgrade;
     ""      close;
+  }
+
+  upstream chatbot_backend {
+    server chatbot-app:8501;
   }
 
   client_max_body_size 64m;
@@ -36,7 +32,7 @@ http {
       proxy_send_timeout  86400;
       proxy_buffering     off;
 
-      proxy_pass $backend;
+      proxy_pass http://chatbot_backend;
     }
   }
 
@@ -69,7 +65,7 @@ http {
       proxy_send_timeout  86400;
       proxy_buffering     off;
 
-      proxy_pass $backend;
+      proxy_pass http://chatbot_backend;
     }
   }
 }


### PR DESCRIPTION
## Summary
- simplify nginx configuration by defining a static upstream for the chatbot
- proxy requests through the new upstream instead of variable mapping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a06ecaeefc8323a495272cf26b1ef3